### PR TITLE
WL-3950: Get availability data from aleph rather than solo

### DIFF
--- a/src/main/java/uk/ac/ox/oucs/sirlouie/LibraryAvailability.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/LibraryAvailability.java
@@ -21,9 +21,8 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
 
 import uk.ac.ox.oucs.sirlouie.daia.ResponseBean;
-import uk.ac.ox.oucs.sirlouie.primo.PrimoService;
+import uk.ac.ox.oucs.sirlouie.primo.AlephService;
 import uk.ac.ox.oucs.sirlouie.properties.SirLouieProperties;
-import uk.ac.ox.oucs.sirlouie.utils.DaiaURI;
 
 @Path("/library")
 public class LibraryAvailability {
@@ -49,9 +48,9 @@ public class LibraryAvailability {
 
 		try {
 
-			PrimoService service = new PrimoService(getProperties().getWebResourseURL());
-			DaiaURI uri = new DaiaURI(id);
-			ResponseBean bean = service.getResource(uri.getDoc());
+			String webResourceURL = getProperties().getWebResourseURL(id);
+			AlephService service = new AlephService(webResourceURL);
+			ResponseBean bean = service.getResource(webResourceURL);
 			JSONObject json = bean.toJSON();
 
 			if (format.equals(FORMAT_JSON)) {

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/daia/Document.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/daia/Document.java
@@ -60,13 +60,48 @@ public class Document {
 				item.setHref(library.getURL());
 				item.setLabel(library.getLabel());
 				item.setStorage(library.getCollection());
+				item.setLibcode(library.getLibrary());
+				item.setLibname(library.getLibraryName());
+				item.setItemshelf(library.getCallNumber());
+				item.setItemdesc(library.getDescription());
+				item.setItemtype(library.getType());
+				if (item.getAvailability()!=null && item.getAvailability().equals("Available")){
+					item.setAvailableitems(1);
+				}
+				else {
+					item.setAvailableitems(0);
+				}
+				item.setTotalitems(1);
+				item.setAvailability(library.getAvailability());
+				item.setMapurl("");
 				Available service = new Available("loan");
 				service.setHref(library.getAvailableURL());
 				item.addAvailableService(service);
 				if (null != library.getLibrary()) {
 					item.setDepartment(new Department(library.getLibrary()));
 				}
-				items.add(item);
+
+				boolean alreadyExists = false;
+				for (Item existingItem : items) {
+					// If the item (= library, shelfmark, description, status) already exists,
+					if (item.getLibcode()!=null && item.getLibcode().equals(existingItem.getLibcode()) &&
+						item.getItemshelf()!=null && item.getItemshelf().equals(existingItem.getItemshelf()) &&
+						item.getItemdesc()!=null && item.getItemdesc().equals(existingItem.getItemdesc()) &&
+						item.getItemtype()!=null && item.getItemtype().equals(existingItem.getItemtype())){
+
+						// Add to total items
+						item.setTotalitems(item.getTotalitems() + 1);
+
+						// Add to available items if Available
+						if (item.getAvailability().equals("Available")){
+							item.setAvailableitems(item.getAvailableitems()+1);
+						}
+						alreadyExists = true;
+					}
+				}
+				if (!alreadyExists){
+					items.add(item);
+				}
 			}
 			
 			if (bean instanceof SearLink) {

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/daia/Item.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/daia/Item.java
@@ -19,7 +19,16 @@ public class Item {
 	private String storage;
 	private String limitation;
 	private String href;
-	
+	private String libcode;
+	private String libname;
+	private String itemshelf;
+	private String itemdesc;
+	private String itemtype;
+	private String availability;
+	private int availableitems;
+	private int totalitems;
+	private String mapurl;
+
 	public Item() {	
 	}
 	
@@ -95,6 +104,78 @@ public class Item {
 		this.href=href;
 	}
 
+	public int getTotalitems() {
+		return totalitems;
+	}
+
+	public void setTotalitems(int totalitems) {
+		this.totalitems = totalitems;
+	}
+
+	public int getAvailableitems() {
+		return availableitems;
+	}
+
+	public void setAvailableitems(int availableitems) {
+		this.availableitems = availableitems;
+	}
+
+	public String getItemtype() {
+		return itemtype;
+	}
+
+	public void setItemtype(String itemtype) {
+		this.itemtype = itemtype;
+	}
+
+	public String getItemdesc() {
+		return itemdesc;
+	}
+
+	public void setItemdesc(String itemdesc) {
+		this.itemdesc = itemdesc;
+	}
+
+	public String getItemshelf() {
+		return itemshelf;
+	}
+
+	public void setItemshelf(String itemshelf) {
+		this.itemshelf = itemshelf;
+	}
+
+	public String getLibname() {
+		return libname;
+	}
+
+	public void setLibname(String libname) {
+		this.libname = libname;
+	}
+
+	public String getLibcode() {
+		return libcode;
+	}
+
+	public void setLibcode(String libcode) {
+		this.libcode = libcode;
+	}
+
+	public String getMapurl() {
+		return mapurl;
+	}
+
+	public void setMapurl(String mapurl) {
+		this.mapurl = mapurl;
+	}
+
+	public String getAvailability() {
+		return availability;
+	}
+
+	public void setAvailability(String availability) {
+		this.availability = availability;
+	}
+
 	public JSONObject toJSON() throws JSONException {
 		
 		JSONObject json = new JSONObject();
@@ -115,6 +196,27 @@ public class Item {
 		if (null != label) {
 			json.put("label", label);
 		}
+		if (null != libcode) {
+			json.put("libcode", libcode);
+		}
+		if (null != libname) {
+			json.put("libname", libname);
+		}
+		if (null != itemshelf) {
+			json.put("itemshelf", itemshelf);
+		}
+		if (null != itemdesc) {
+			json.put("itemdesc", itemdesc);
+		}
+		if (null != itemtype) {
+			json.put("itemtype", itemtype);
+		}
+		json.put("availableitems", availableitems);
+		json.put("totalitems", totalitems);
+		if (null != mapurl) {
+			json.put("mapurl", mapurl);
+		}
+
 		
 		JSONArray availableList = new JSONArray();
 		for (Available service : availableServices) {

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/primo/AlephService.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/primo/AlephService.java
@@ -19,14 +19,14 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 
-public class PrimoService {
+public class AlephService {
 	
 	Client client;
 	WebResource webResource;
 	private String nameSpaceURI = "http://www.exlibrisgroup.com/xsd/jaguar/search";
-	private static Log log = LogFactory.getLog(PrimoService.class);
+	private static Log log = LogFactory.getLog(AlephService.class);
 	
-	public PrimoService(String webResourceURL) {
+	public AlephService(String webResourceURL) {
 	    
 		//log.debug(webResourceURL);
 		client = Client.create();
@@ -37,22 +37,19 @@ public class PrimoService {
 		
 		//log.debug("getResource ["+id+"]");
 	    MultivaluedMap<String, String> params = new MultivaluedMapImpl();
-	    params.add("institution", "OXVU1");
-	    params.add("docId", id);
-	    params.add("isLoggedIn", "false");
-	    params.add("onCampus", "false");
-	     
+	    params.add("view", "full");
+
 	    WebResource query = webResource.queryParams(params);
 	    if (log.isDebugEnabled()) {
 	    	log.debug("Making request: "+ query.getURI().toString());
 	    }
-	    
+
 	    String responseXML = query.get(String.class);
 	    if (log.isDebugEnabled()) {
 	    	log.debug("Got response: "+ responseXML);
 	    }
-	    
-	    // Create a DAIA response.
+	    responseXML = responseXML.replaceAll("&apos;", "\'");
+		// Create a DAIA response.
 	    ResponseBean responseBean = new ResponseBean(id);
 	    Collection<SearObject> beans = filterResponse(nameSpaceURI, responseXML);
 		responseBean.addSearObjects(beans);

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/primo/PrimoXMLFilter.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/primo/PrimoXMLFilter.java
@@ -58,7 +58,7 @@ public class PrimoXMLFilter extends XMLFilterImpl {
 		
 		tempVal="";
 		
-		if (uri.equals(nameSpaceURI) && localName.equals("ERROR")) {
+		if (localName.equals("ERROR")) {
 			SearError searError = new SearError();
 			for (int i=0; i<atts.getLength(); i++) {
 				if (atts.getLocalName(i).equals("MESSAGE")) {
@@ -69,10 +69,10 @@ public class PrimoXMLFilter extends XMLFilterImpl {
 			}
 			beans.add(searError);
 			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("LIBRARY")) {
+		} else if (localName.equals("item")) {
 			searLibrary = new SearLibrary();
 			
-		} 
+		}
 	}
 	
 	@Override
@@ -81,35 +81,47 @@ public class PrimoXMLFilter extends XMLFilterImpl {
 		
 		//log.debug("endElement ["+qName+":"+localName+"]");
 		
-		if (uri.equals(nameSpaceURI) && localName.equals("ERROR")) {
+		if (localName.equals("ERROR")) {
 			//throw new SAXException(searError.getMessage());
 			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("LIBRARY")) {
+		} else if (localName.equals("item")) {
 			beans.add(searLibrary);
-			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("institution")) {
+
+		} else if (localName.equals("institution")) {
 			searLibrary.setInstitution(tempVal);
 			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("library")) {
+		} else if (localName.equals("z30-sub-library-code")) {
 			searLibrary.setLibrary(tempVal);
 			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("status")) {
+		} else if (localName.equals("z30-sub-library")) {
+			searLibrary.setLibraryName(tempVal);
+
+		} else if (localName.equals("z30-description")) {
+			searLibrary.setDescription(tempVal);
+
+		} else if (localName.equals("z30-item-status")) {
+			searLibrary.setType(tempVal);
+
+		} else if (localName.equals("z30-item-status")) {
 			searLibrary.setStatus(tempVal);
-			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("collection")) {
+
+		} else if (localName.equals("status")) {
+			searLibrary.setAvailability(tempVal);
+
+		} else if (localName.equals("collection")) {
 			searLibrary.setCollection(tempVal);
-			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("callNumber")) {
+
+		} else if (localName.equals("z30-call-no")) {
 			searLibrary.setCallNumber(tempVal);
-			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("url")) {
+
+		} else if (localName.equals("url")) {
 			searLibrary.setURL(tempVal);
-			
-		} else if (uri.equals(nameSpaceURI) && localName.equals("linktorsrc")) {
+
+		} else if (localName.equals("linktorsrc")) {
 			SearLink searLink = new SearLink();
 			searLink.setHref(tempVal);
 			beans.add(searLink);
-			
+
 		}
 	}
 

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/properties/SakaiProperties.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/properties/SakaiProperties.java
@@ -8,7 +8,7 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 public class SakaiProperties extends SirLouieProperties {
 
 	private static final long serialVersionUID = 1L;
-	public final static String WEBRESOURCE_URL = "sirlouie.webresourceURL";
+	public final static String WEBRESOURCE_URL = "sirlouie.webresourceURL.aleph";
 
 	/**
 	 * This class allows the location of the sirlouie filter properties to be loaded from a 
@@ -24,7 +24,9 @@ public class SakaiProperties extends SirLouieProperties {
 		setProperty(WEBRESOURCE_URL, ServerConfigurationService.getString(WEBRESOURCE_URL));
 	}
 
-	public String getWebResourseURL() {
-		return getProperty(WEBRESOURCE_URL);
+	public String getWebResourseURL(String id) {
+		String webResourceURL = getProperty(WEBRESOURCE_URL);
+		id = id.replaceAll("oxfaleph", "BIB01");
+		return webResourceURL.replaceAll("<<<OXFALEPHID>>>", id);
 	}
 }

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/properties/SirLouieProperties.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/properties/SirLouieProperties.java
@@ -12,8 +12,10 @@ public abstract class SirLouieProperties extends Properties {
 	public SirLouieProperties() {
 	}
 	
-	public String getWebResourseURL() {
-		return getProperty("webresourceURL");
+	public String getWebResourseURL(String id) {
+		String webResourceURL = getProperty("webresourceURL.aleph");
+		id = id.replaceAll("oxfaleph", "BIB01");
+		return webResourceURL.replaceAll("<<<OXFALEPHID>>>", id);
 	}
 
 }

--- a/src/main/java/uk/ac/ox/oucs/sirlouie/reply/SearLibrary.java
+++ b/src/main/java/uk/ac/ox/oucs/sirlouie/reply/SearLibrary.java
@@ -8,6 +8,9 @@ public class SearLibrary implements SearObject {
 	private String institution;
 	private String label;
 	private String library;
+	private String libraryName;
+	private String description;
+	private String availability;
 	private String status;
 	private String type;
 	private String url;
@@ -15,11 +18,14 @@ public class SearLibrary implements SearObject {
 	
 	public SearLibrary() {}
 	
-	public SearLibrary(String institution, String library, String status, String collection, String callNumber, String url) {
+	public SearLibrary(String institution, String library, String libraryName, String description, String availability, String status, String collection, String callNumber, String url) {
 		this.callNumber = callNumber;
 		this.collection = collection;
 		this.institution = institution;
 		this.library = library;
+		this.libraryName = libraryName;
+		this.description = description;
+		this.availability = availability;
 		this.status = status;
 		this.url = url;
 	}
@@ -70,6 +76,27 @@ public class SearLibrary implements SearObject {
 
 	public void setLibrary(String library) {
 		this.library = library;
+	}
+	public String getLibraryName() {
+		return libraryName;
+	}
+
+	public void setLibraryName(String libraryName) {
+		this.libraryName = libraryName;
+	}
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+	public String getAvailability() {
+		return availability;
+	}
+
+	public void setAvailability(String availability) {
+		this.availability = availability;
 	}
 	
 	public String getStatus() {

--- a/src/test/java/uk/ac/ox/oucs/sirlouie/AlephServiceTest.java
+++ b/src/test/java/uk/ac/ox/oucs/sirlouie/AlephServiceTest.java
@@ -15,13 +15,12 @@ import org.xml.sax.SAXException;
 import uk.ac.ox.oucs.sirlouie.daia.Document;
 import uk.ac.ox.oucs.sirlouie.daia.Item;
 import uk.ac.ox.oucs.sirlouie.daia.ResponseBean;
-import uk.ac.ox.oucs.sirlouie.primo.PrimoService;
-import uk.ac.ox.oucs.sirlouie.reply.SearLibrary;
+import uk.ac.ox.oucs.sirlouie.primo.AlephService;
 import uk.ac.ox.oucs.sirlouie.reply.SearObject;
 
-public class PrimoServiceTest extends TestCase {
+public class AlephServiceTest extends TestCase {
 
-	PrimoService service;
+	AlephService service;
 
 	private String nameSpaceURI = "http://www.exlibrisgroup.com/xsd/jaguar/search";
 
@@ -502,7 +501,7 @@ public class PrimoServiceTest extends TestCase {
 	*/
 	protected void setUp() throws Exception {
 		super.setUp();
-		service = new PrimoService(WEBRESOURCE_URL);
+		service = new AlephService(WEBRESOURCE_URL);
 	}
 
 	protected void tearDown() throws Exception {
@@ -552,7 +551,7 @@ public class PrimoServiceTest extends TestCase {
 
 		try {
 			Collection<SearObject> beans =
-				PrimoService.filterResponse(nameSpaceURI, OLIS_XML);
+				AlephService.filterResponse(nameSpaceURI, OLIS_XML);
 			Assert.assertEquals(2, beans.size());
 
 		} catch (Exception e) {
@@ -565,7 +564,7 @@ public class PrimoServiceTest extends TestCase {
 
 		try {
 			Collection<SearObject> beans =
-				PrimoService.filterResponse(nameSpaceURI, ORA_XML);
+				AlephService.filterResponse(nameSpaceURI, ORA_XML);
 			Assert.assertEquals(1, beans.size());
 
 		} catch (Exception e) {
@@ -589,7 +588,7 @@ public class PrimoServiceTest extends TestCase {
 	public void testFilterErrorResponse() {
 
 		try {
-			PrimoService.filterResponse(nameSpaceURI, errorXML);
+			AlephService.filterResponse(nameSpaceURI, errorXML);
 
 			//Assert.fail("Exception expected");
 
@@ -622,7 +621,7 @@ public class PrimoServiceTest extends TestCase {
 	public void testORAoJSON() throws Exception {
 		String id = "ORAdebe641a-17ca-4196-ab2c-fe7565ced721";
 		ResponseBean responseBean = new ResponseBean(id);
-		Collection<SearObject> beans = PrimoService.filterResponse(nameSpaceURI, ORA_XML);
+		Collection<SearObject> beans = AlephService.filterResponse(nameSpaceURI, ORA_XML);
 		responseBean.addSearObjects(beans);
 
 		JSONObject json = responseBean.toJSON("2009-06-09T15:39:52.831+02:00");
@@ -643,7 +642,7 @@ public class PrimoServiceTest extends TestCase {
 
 	public void testNewXmlResponse() throws SAXException, IOException {
 		// Test that the library name lookups are working.
-		Collection<SearObject> beans = PrimoService.filterResponse(nameSpaceURI, NEW_OLIS_XML);
+		Collection<SearObject> beans = AlephService.filterResponse(nameSpaceURI, NEW_OLIS_XML);
 		assertFalse(beans.isEmpty());
 		ResponseBean response = new ResponseBean();
 		response.addSearObjects(beans);


### PR DESCRIPTION
We want to get our availability data from aleph rather than solo as it has better data, i.e., from eg 'http://aleph-prd.bodleian.ox.ac.uk:1891/rest-dlf/record/BIB01016729063/items?view=full' rather than 'http://solo.bodleian.ox.ac.uk/PrimoWebServices/xservice/getit'.  So we need to query aleph and then parse the XML returned (which is different) in a different way.  

Then we need to group the 'items' by library, shelfmark, description and lending status so that each grouping represents a row of availability for that group.

